### PR TITLE
Fix GitHub casing in navigation link

### DIFF
--- a/source/partials/_navigation.haml
+++ b/source/partials/_navigation.haml
@@ -1,4 +1,4 @@
 %nav.page-navigation
   %ul.navigation-list
     %li.navigation-list-item
-      = link_to "Github", "https://github.com/thoughtbot/foundry", class: "navigation-list-item-link"
+      = link_to "GitHub", "https://github.com/thoughtbot/foundry", class: "navigation-list-item-link"


### PR DESCRIPTION
GitHub should be written as "GitHub".