### PR TITLE
Add Foundry Progress to list of collections

### DIFF
--- a/data/library.yml
+++ b/data/library.yml
@@ -13,3 +13,10 @@ families:
     path: "/foundry-fellowly/lib/"
     author_handle: "@whmii"
     author_url: "https://twitter.com/whmii"
+  foundry-progress:
+    title: "Progress"
+    repo_url: "https://github.com/thoughtbot/foundry-progress.git"
+    description: "A family of animated spinners, loaders and progress bars."
+    path: "/foundry-progress/lib/"
+    author_handle: "@joshuaogle"
+    author_url: "https://twitter.com/joshuaogle"


### PR DESCRIPTION
I created a collection for spinners, loading bars, etc. I really like SVG icons for styling these and having a collection with nice markup would be great.
https://github.com/thoughtbot/foundry-progress

@whmii What do you think?