### PR TITLE
Use a protocol relative URL to load google fonts

### DIFF
--- a/source/assets/stylesheets/app.scss
+++ b/source/assets/stylesheets/app.scss
@@ -1,5 +1,5 @@
 @charset "utf-8";
-@import url(http://fonts.googleapis.com/css?family=Merriweather:400italic,400,900,300italic,300,700,700italic,900italic|Montserrat:400,700&subset=latin,latin-ext);
+@import url(//fonts.googleapis.com/css?family=Merriweather:400italic,400,900,300italic,300,700,700italic,900italic|Montserrat:400,700&subset=latin,latin-ext);
 
 // Core
 @import 'bourbon';


### PR DESCRIPTION
Avoids insecure resource warnings in browsers.
